### PR TITLE
Fix typo in sparse_utility.h copy_from_to

### DIFF
--- a/sparse_utilities.h
+++ b/sparse_utilities.h
@@ -512,7 +512,7 @@ namespace sym_lib {
 
  void copy_from_to(CSR *src, CSR *dst){
   for (int i = 0; i < src->n; ++i) {
-   dst->p[i] = dst->p[i];
+   dst->p[i] = src->p[i];
    for (int j = src->p[i]; j < src->p[i + 1]; ++j) {
     dst->i[j] = src->i[j];
     dst->x[j] = src->x[j];


### PR DESCRIPTION
Found a typo in sparse_utility.h, may also affect the nasoq repo.